### PR TITLE
chore: added 17.0 as react peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-intl": "^5.4.5"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9 || ^17.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.0",


### PR DESCRIPTION
Should be safe to allow also react 17.0 as peer dependency.